### PR TITLE
Make small improvements to R script and Dockerfile

### DIFF
--- a/Driver_Mutation_Results/workflow/docker/driver_mutation_results/Dockerfile
+++ b/Driver_Mutation_Results/workflow/docker/driver_mutation_results/Dockerfile
@@ -1,6 +1,7 @@
-FROM rocker/tidyverse:3.6.1 
+FROM rocker/tidyverse:4.0.2 
 
 RUN Rscript -e "install.packages('argparse')"
+RUN Rscript -e "install.packages('feather')"
 
 COPY bin/* /usr/local/bin/
 RUN chmod a+x /usr/local/bin/*.R

--- a/Driver_Mutation_Results/workflow/docker/driver_mutation_results/bin/calculate_driver_results.R
+++ b/Driver_Mutation_Results/workflow/docker/driver_mutation_results/bin/calculate_driver_results.R
@@ -109,9 +109,9 @@ if(args$input_file_type == "feather") {
 
 if(args$output_file_type == "feather") {
   write_func <- feather::write_feather
-} else if(args$input_file_type == "csv") {
+} else if(args$output_file_type == "csv") {
   write_func <- readr::write_csv
-} else if(args$input_file_type == "tsv") {
+} else if(args$output_file_type == "tsv") {
   write_func <- readr::write_tsv
 } else {
   stop("Unsupported output file type")

--- a/Driver_Mutation_Results/workflow/docker/driver_mutation_results/bin/calculate_driver_results.R
+++ b/Driver_Mutation_Results/workflow/docker/driver_mutation_results/bin/calculate_driver_results.R
@@ -1,3 +1,5 @@
+#!/usr/bin/env Rscript
+
 library(rlang)
 library(magrittr)
 library(argparse)


### PR DESCRIPTION
The commit messages explain each change. Briefly:

1. The copy-paste issue prevented the use of any output format other than `feather`. 
2. The `across()` function is only available in version 1.0 or later of dplyr. This required at least an upgrade to `rocker/tidyverse:4.0`, so I opted for the latest version (`4.0.2`). 
3. For simplicity, I added a shebang line to the R script so it can be called from anywhere without an absolute path. 