### PR TITLE
Updates `immune_subtype_clustering` docker container version

### DIFF
--- a/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl
+++ b/Immune_Subtype_Clustering/workflow/steps/immune_subtype_clustering/immune_subtype_clustering.cwl
@@ -11,7 +11,7 @@ requirements:
 
 hints:
 - class: DockerRequirement
-  dockerPull: quay.io/cri-iatlas/immune_subtype_clustering:1.1
+  dockerPull: quay.io/cri-iatlas/immune_subtype_clustering:1.0
 
 inputs:
 


### PR DESCRIPTION
`quay.io/cri-iatlas/immune_subtype_clustering:1.1` does not exist. The only tag for this docker image that is available is `1.0`.  I was able to run the workflow successfully with `quay.io/cri-iatlas/immune_subtype_clustering:1.0`.